### PR TITLE
Parent pom.xml clean up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.excilys.soja</groupId>
 	<artifactId>soja-parent</artifactId>
@@ -10,19 +11,20 @@
 		<java.version>1.6</java.version>
 
 		<!-- Maven plugins -->
-		<maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>2.4</maven-compiler-plugin.version>
 		<maven-assembly-plugin.version>2.3</maven-assembly-plugin.version>
 		<maven-release-plugin.version>2.3</maven-release-plugin.version>
+		<maven-dependency-plugin.version>2.4</maven-dependency-plugin.version>
 
-		<netty.version>3.3.1.Final</netty.version>
+		<netty.version>3.4.5.Final</netty.version>
 		<commons-lang.version>2.6</commons-lang.version>
-		<logback.version>1.0.0</logback.version>
+		<logback.version>1.0.3</logback.version>
 	</properties>
 
 	<scm>
 		<developerConnection>scm:git|ssh://git@github.com/excilys/soja.git</developerConnection>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<developers>
 		<developer>
@@ -72,6 +74,15 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>${maven-compiler-plugin.version}</version>
+					<configuration>
+						<encoding>${project.build.sourceEncoding}</encoding>
+						<source>${java.version}</source>
+						<target>${java.version}</target>
+					</configuration>
+				</plugin>
+				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>${maven-assembly-plugin.version}</version>
 					<configuration>
@@ -91,29 +102,50 @@
 				</plugin>
 
 				<plugin>
-					<!-- Use release:prepare then release:deploy (or release:rollback to cancel) -->
-					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>${maven-dependency-plugin.version}</version>
+				</plugin>
+
+				<plugin>
+					<!-- Use release:prepare then release:deploy (or release:rollback to 
+						cancel) -->
 					<artifactId>maven-release-plugin</artifactId>
 					<version>${maven-release-plugin.version}</version>
+				</plugin>
+
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-dependency-plugin</artifactId>
+										<versionRange>[${maven-dependency-plugin.version},)</versionRange>
+										<goals>
+											<goal>copy-dependencies</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
 
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven-compiler-plugin.version}</version>
-				<configuration>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-
 			<!-- Copy all dependencies in the folder target/lib -->
 			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.1</version>
 				<executions>
 					<execution>
 						<phase>install</phase>
@@ -129,12 +161,6 @@
 
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-			</plugin>
-
-			<!-- Use release:prepare then release:deploy (or release:rollback to cancel) -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
- Make m2e compatible (ignore copy-dependencies from lifecyle)
- Upgrade netty to 3.4.5 (tons of clean up and bug fixes since 3.3.1, yet compatible)
- Upgrade logback to 1.0.3
